### PR TITLE
Fix missing AppViewModel environment object

### DIFF
--- a/Weather.ly/Weather_lyApp.swift
+++ b/Weather.ly/Weather_lyApp.swift
@@ -28,21 +28,21 @@ struct WeatherlyApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if viewModel.advancedMode {
-                NavigationStack(path: $viewModel.navigationPath) {
-                    CityListView()
-                        .environmentObject(viewModel)
-                        .navigationDestination(for: City.self) { city in
-                            CalendarView(city: city)
-                                .environmentObject(viewModel)
-                        }
-                }
-            } else {
-                NavigationStack {
-                    SimpleCityListView()
-                        .environmentObject(viewModel)
+            Group {
+                if viewModel.advancedMode {
+                    NavigationStack(path: $viewModel.navigationPath) {
+                        CityListView()
+                            .navigationDestination(for: City.self) { city in
+                                CalendarView(city: city)
+                            }
+                    }
+                } else {
+                    NavigationStack {
+                        SimpleCityListView()
+                    }
                 }
             }
+            .environmentObject(viewModel)
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `AppViewModel` is injected at the app's root view

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6880861450ec8328a2060ca320b53e8e