### PR TITLE
Show ensemble model info

### DIFF
--- a/Weather.ly/SimpleModeViews.swift
+++ b/Weather.ly/SimpleModeViews.swift
@@ -80,6 +80,9 @@ struct SimpleForecastView: View {
     @State private var precipLowerQuartile: [Date: Double] = [:]
     @State private var precipUpperQuartile: [Date: Double] = [:]
 
+    // Info alert
+    @State private var showModelInfo = false
+
     // Metrics picker
     enum Metric: String, CaseIterable, Identifiable {
         case temperature     = "Temp"
@@ -147,6 +150,18 @@ struct SimpleForecastView: View {
             }
         }
         .navigationTitle(city.name)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { showModelInfo = true } label: {
+                    Image(systemName: "info.circle")
+                }
+            }
+        }
+        .alert("Model Info", isPresented: $showModelInfo) {
+            Button("Got it") { }
+        } message: {
+            Text("Temp Dist and Rain Dist use the DWD icon_seamless ensemble model.")
+        }
         .task { fetchData() }
     }
 


### PR DESCRIPTION
## Summary
- let the user know which forecast model is used for the distribution columns
- add an info button to SimpleForecastView with a brief description of the model

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6880ab1b448c8328a1d99296339ccbbc